### PR TITLE
Fill in missing magnitudes + additional figure tweaks

### DIFF
--- a/code/04_build-release/code/01_coalesce-teams.R
+++ b/code/04_build-release/code/01_coalesce-teams.R
@@ -42,7 +42,7 @@ ds_harv_sel <- ds_harv |> semi_join(hv_counties, by = c("state", "county_name"))
 # temp Fixes
 # https://github.com/kuriwaki/cvr_harvard-mit_scripts/issues/308#issuecomment-2212066285
 seneca_rm <- ds_meds |>
-  filter( state == "OHIO", county_name == "SENECA", office == "STATE HOUSE") |>
+  filter(state == "OHIO", county_name == "SENECA", office == "STATE HOUSE") |>
   collect() |>
   filter(n() == 2, .by = cvr_id) |>
   filter(district == "087")
@@ -55,6 +55,7 @@ ds_meds |>
   reallocate_wi_prec() |>
   custom_add_party() |>
   fmt_for_release() |>
+  fill_magnitude() |>
   left_join(prec_names, by = c("state", "county_name", "precinct"), relationship = "many-to-one") |>
   write_dataset(
     path = PATH_interim,
@@ -65,6 +66,7 @@ ds_meds |>
 ## add Harvard
 ds_harv_sel |>
   fmt_for_release() |>
+  fill_magnitude() |>
   left_join(prec_names, by = c("state", "county_name", "precinct"), relationship = "many-to-one") |>
   write_dataset(
     path = PATH_interim,

--- a/code/04_build-release/code/fmt_release.R
+++ b/code/04_build-release/code/fmt_release.R
@@ -26,3 +26,19 @@ fmt_for_release <- function(tbl) {
       .before = party_detailed
     )
 }
+
+
+fill_magnitude <- function(tbl) {
+  m_states <- c("ARIZONA", "WEST VIRGINIA")
+
+  tbl |>
+    mutate(
+      magnitude = ifelse(
+        (is.na(magnitude) | magnitude == -1) &
+          !(state %in% m_states & office == "STATE HOUSE"), 1, magnitude),
+      magnitude = ifelse(
+        (is.na(magnitude) | magnitude == -1) &
+          (state %in% "ARIZONA" & office == "STATE HOUSE"), 2, magnitude)
+      # WV districts differ in their magnitude, but AZ is all 2
+    )
+}

--- a/code/05_paper-analyze/00_paths.R
+++ b/code/05_paper-analyze/00_paths.R
@@ -1,4 +1,4 @@
-library(fs)
+suppressPackageStartupMessages(library(fs))
 
 username <- Sys.info()["user"]
 if (username == "shirokuriwaki" | str_detect(username, "^sk[0-9]+")) {

--- a/code/05_paper-analyze/01_numbers.R
+++ b/code/05_paper-analyze/01_numbers.R
@@ -1,6 +1,8 @@
-library(tidyverse)
-library(arrow)
-library(glue)
+suppressPackageStartupMessages({
+  library(tidyverse)
+  library(arrow)
+  library(glue)
+})
 source("00_paths.R")
 
 write_n <- function (tbl, path, dir = "numbers") {

--- a/code/05_paper-analyze/02a_map-states.R
+++ b/code/05_paper-analyze/02a_map-states.R
@@ -1,8 +1,10 @@
-library(tidyverse)
-library(sf)
-library(scales)
-library(arrow)
-library(urbnmapr) # renv::install("UrbanInstitute/urbnmapr")
+suppressPackageStartupMessages({
+  library(tidyverse)
+  library(arrow)
+  library(sf)
+  library(scales)
+  library(urbnmapr) # renv::install("UrbanInstitute/urbnmapr")
+})
 source("00_paths.R")
 
 shp_us <- urbnmapr::get_urbn_map(map = "states", sf = TRUE) #

--- a/code/05_paper-analyze/02b_list-counties.R
+++ b/code/05_paper-analyze/02b_list-counties.R
@@ -69,5 +69,5 @@ for (i in 1:nrow(dat_fmt)) {
 sink()
 
 output_df <- tibble(x = unlist(rows_list))
-write_xlsx(output_df, "tables/table_04.xlsx")
+write_xlsx(output_df, "tables/table_05.xlsx")
 

--- a/code/05_paper-analyze/02b_list-counties.R
+++ b/code/05_paper-analyze/02b_list-counties.R
@@ -35,7 +35,7 @@ rows_list <- list()
 # line by line so we can do multicols ----
 st_counter <- ""
 
-sink("tables/tab_counties_text.tex")
+sink("tables/table_05.tex")
 
 for (i in 1:nrow(dat_fmt)) {
   # new state

--- a/code/05_paper-analyze/02b_list-counties.R
+++ b/code/05_paper-analyze/02b_list-counties.R
@@ -1,8 +1,10 @@
-library(tidyverse)
-library(arrow)
-library(fs)
-library(glue)
-library(writexl)
+suppressPackageStartupMessages({
+  library(tidyverse)
+  library(arrow)
+  library(glue)
+  library(fs)
+  library(writexl)
+})
 source("00_paths.R")
 
 # count voters by county

--- a/code/05_paper-analyze/02b_list-counties.R
+++ b/code/05_paper-analyze/02b_list-counties.R
@@ -24,7 +24,10 @@ dat_fmt <- dat |>
   ) |>
   mutate(state = str_to_title(state),
          county = str_to_title(county_name),
-         county = recode(county, Statewide = "(Statewide)")) |>
+         county = recode(county, Statewide = "(Statewide)"),
+         county = recode(county, Mchenry = "McHenry",
+                         Dekalb = "DeKalb", Mcduffie = "McDuffie")
+         ) |>
   arrange(state, county)
 
 rows_list <- list()
@@ -66,5 +69,5 @@ for (i in 1:nrow(dat_fmt)) {
 sink()
 
 output_df <- tibble(x = unlist(rows_list))
-write_xlsx(output_df, "tables/table_05.xlsx")
+write_xlsx(output_df, "tables/table_04.xlsx")
 

--- a/code/05_paper-analyze/03a_state-tilt.R
+++ b/code/05_paper-analyze/03a_state-tilt.R
@@ -55,6 +55,7 @@ state_cvr <- ds |>
 # Population ---
 # all 50 states
 all_states_v <- ds_v |>
+  filter(state != "DISTRICT OF COLUMBIA") |>
   tally_votes() |>
   mutate(state = "All 50 States")
 

--- a/code/05_paper-analyze/03a_state-tilt.R
+++ b/code/05_paper-analyze/03a_state-tilt.R
@@ -1,8 +1,10 @@
-library(tidyverse)
-library(scales)
-library(arrow)
-library(gt)
-library(glue)
+suppressPackageStartupMessages({
+  library(tidyverse)
+  library(arrow)
+  library(glue)
+  library(gt)
+  library(scales)
+})
 source("00_paths.R")
 
 # Database connections
@@ -99,7 +101,7 @@ state_tb <- state_cvr |>
     )) |>
   tab_options(table.font.size = px(13)) |>
   tab_spanner("Percent Biden", columns = matches("_prez")) |>
-  tab_spanner("Voters", columns = matches("voters")) |>
+  tab_spanner("Biden, Trump, and Jorgensen Voters", columns = matches("voters")) |>
   gt::sub_missing() |>
   cols_add(SPACE = "", .after = diff_prez) |>
   cols_label(SPACE = md("&emsp;&emsp;&emsp;&emsp;"))

--- a/code/05_paper-analyze/03a_state-tilt.R
+++ b/code/05_paper-analyze/03a_state-tilt.R
@@ -84,8 +84,8 @@ state_tb <- state_cvr |>
     state = str_to_title(state),
     diff_prez  = scales::percent(dem_prez.x - dem_prez.y, accuracy = 1, suffix = "",
                                  style_positive = "plus"),
-    pct_voters = scales::percent(n_voters.x / n_voters.y, accuracy = 1),
-    pct_voters = replace(pct_voters, pct_voters == "0%", "<1%")
+    pct_voters = scales::percent(n_voters.x / n_voters.y, accuracy = 1, suffix = ""),
+    pct_voters = replace(pct_voters, pct_voters == "0", "<1")
     ) |>
   gt() |>
   fmt_percent(matches("_prez"), decimals = 1) |>
@@ -98,7 +98,7 @@ state_tb <- state_cvr |>
     str_detect(x, "pct") ~ "%"
     )) |>
   tab_options(table.font.size = px(13)) |>
-  tab_spanner("% Biden", columns = matches("_prez")) |>
+  tab_spanner("Percent Biden", columns = matches("_prez")) |>
   tab_spanner("Voters", columns = matches("voters")) |>
   gt::sub_missing() |>
   cols_add(SPACE = "", .after = diff_prez) |>

--- a/code/05_paper-analyze/03b_county-census.R
+++ b/code/05_paper-analyze/03b_county-census.R
@@ -1,8 +1,10 @@
-library(tidyverse)
-library(tidycensus)
-library(arrow)
-library(gt)
-library(fs)
+suppressPackageStartupMessages({
+  library(tidyverse)
+  library(tidycensus)
+  library(arrow)
+  library(glue)
+  library(gt)
+})
 source("00_paths.R")
 
 calc_summary_stats <- function(data, variable) { # func to calculate sum stats
@@ -200,6 +202,8 @@ sumstats_w <- sum_stats |>
   tab_spanner("Overall", columns = matches("^Total")) |>
   tab_spanner("Average", columns = matches("^Mean")) |>
   tab_spanner("Median", columns = matches("^Median")) |>
+  tab_spanner("Std. Dev.", columns = matches("^SD")) |>
+  tab_caption(caption = "\\textbf{Characteristics of Counties Used}. \\textit{Comparison of the counties in our sample (CVR) with all counties in the United States (Nation). Data come from the 2020 Decennial Census}. \\label{tab:census}")
 
 sumstats_w |>
   gtsave("tables/table_03.tex")

--- a/code/05_paper-analyze/03b_county-census.R
+++ b/code/05_paper-analyze/03b_county-census.R
@@ -2,6 +2,8 @@ library(tidyverse)
 library(tidycensus)
 library(arrow)
 library(gt)
+library(fs)
+source("00_paths.R")
 
 calc_summary_stats <- function(data, variable) { # func to calculate sum stats
   tibble(
@@ -240,25 +242,24 @@ sumstats_w <- sum_stats |>
       Our.Data
     )
   ) |>
-  dplyr::rename(
-    `Mean_Census` = All.U.S..Counties_Mean,
+  dplyr::select(
+    Variable,
     `Mean_OurData` = Our.Data_Mean,
-    `Median_Census` = All.U.S..Counties_Median,
+    `Mean_Census` = All.U.S..Counties_Mean,
     `Median_OurData` = Our.Data_Median,
-    `SD_Census` = All.U.S..Counties_SD,
-    `SD_OurData` = Our.Data_SD
+    `Median_Census` = All.U.S..Counties_Median,
+    `SD_OurData` = Our.Data_SD,
+    `SD_Census` = All.U.S..Counties_SD
   ) |>
   relocate(Variable, starts_with("Mean"), starts_with("Median"), starts_with("SD")) |>
   gt() |>
-  fmt_percent(matches("_Census|_OurData"), decimals = 3, scale_values = F) |>
+  tab_options(table.font.size = px(13)) |>
+  fmt_number(matches("_Census|_OurData"), decimals = 1) |>
   cols_label_with(fn = \(x) case_when(x == "Variable" ~ "", str_detect(x, "OurData") ~ "CVR", str_detect(x, "Census") ~ "Nation")) |>
   tab_spanner("Mean", columns = matches("^Mean")) |>
   tab_spanner("Median", columns = matches("^Median")) |>
-  tab_spanner("Standard Dev.", columns = matches("^SD")) |>
-  gt::sub_missing()
+  tab_spanner("Standard Dev.", columns = matches("^SD"))
 
-sumstats_w |>
-  gtsave("tables/table_S2.docx")
 
 sumstats_w |>
   gtsave("tables/table_S2.tex")

--- a/code/05_paper-analyze/03b_county-census.R
+++ b/code/05_paper-analyze/03b_county-census.R
@@ -262,4 +262,4 @@ sumstats_w <- sum_stats |>
 
 
 sumstats_w |>
-  gtsave("tables/table_S2.tex")
+  gtsave("tables/table_03.tex")

--- a/code/05_paper-analyze/04_discrepancy-stats.R
+++ b/code/05_paper-analyze/04_discrepancy-stats.R
@@ -1,8 +1,11 @@
-library(tidyverse)
-library(readxl)
-library(arrow)
-library(patchwork)
-library(gt)
+suppressPackageStartupMessages({
+  library(tidyverse)
+  library(arrow)
+  library(glue)
+  library(readxl)
+  library(patchwork)
+  library(gt)
+})
 source("00_paths.R")
 
 # Read in comparison data
@@ -45,8 +48,8 @@ county_level <- dat_county |>
       # "no entry in Baltz",
       "unclassified"
     )
-    )
-    )
+  )
+  )
 
 # State x Office-level % differences
 cand_dist_level <- dat_cand |>

--- a/code/05_paper-analyze/05_precinct-errors.R
+++ b/code/05_paper-analyze/05_precinct-errors.R
@@ -1,5 +1,8 @@
-library(tidyverse)
-library(arrow)
+suppressPackageStartupMessages({
+  library(tidyverse)
+  library(arrow)
+  library(glue)
+})
 source("00_paths.R")
 
 # counties to compare


### PR DESCRIPTION
This PR:

- Fills in magnitudes of -1 and NA with assumed magnitudes.
- Only AZ state house needs a 2. West Virginia had no missings.

- I also checked, separately, Maricopa's state house counts (#158) compared to the official returns (https://elections.maricopa.gov/asset/jcr:e2f15812-99c3-4bf5-8c40-49a8401b2bc3/11-03-2020-1%20Final%20Official%20Summary%20Report%20NOV2020.pdf). The candidate votes seem to match up exactly, although the undervotes don't quite. I forgot we are using MEDSL's version for Maricopa.